### PR TITLE
チェックボックスの解決/learning_programming_languagesのデータ型をintegerに変更

### DIFF
--- a/n_app/app/models/member.rb
+++ b/n_app/app/models/member.rb
@@ -30,7 +30,19 @@ class Member < ApplicationRecord
     2 => "C",
     4 => "C#",
     8 => "C++",
-    16 => "Python"
+    16 => "Python",
+    32 => "Java",
+    64 => "Go",
+    128 => "PHP",
+    256 => "JavaScript",
+    512 => "R",
+    1024 => "HTML/CSS",
+    2048 => "Swift",
+    4096 => "Kotlin",
+    8192 => "Rust",
+    16384 => "Objective-C",
+    32768 => "TypeScript",
+    65536 => "SQL"
   }.freeze
 
   def calculate_select_pl(select_pl)

--- a/n_app/app/views/members/edit.html.erb
+++ b/n_app/app/views/members/edit.html.erb
@@ -44,15 +44,15 @@
       <tr>
         <th>自己紹介</th>
         <td><%= member.text_area :intro, placeholder: "自己紹介" %></td>
+      </tr>
+      <tr>
         <th>学習中プログラミング言語</th>
         <td>
         <% Member::PROGRAMMING_LANGUAGES.each do |pl_num, language| %>
           <% if (pl_num & member.object.learning_programming_languages) != 0 %>
-          <p>selected</p>
-            <%= member.check_box :selected_languages, { multiple: true }, pl_num, {checked: true} %>
+            <%= member.check_box :selected_languages, { multiple: true, checked: true }, pl_num %>
             <%= member.label :selected_languages, language, value: pl_num %>
           <% else %>
-          <p>no</p>
             <%= member.check_box :selected_languages, { multiple: true }, pl_num, {} %>
             <%= member.label :selected_languages, language, value: pl_num %>
           <% end %>

--- a/n_app/db/migrate/20240706062750_change_data_learning_programming_languages_to_members.rb
+++ b/n_app/db/migrate/20240706062750_change_data_learning_programming_languages_to_members.rb
@@ -1,0 +1,5 @@
+class ChangeDataLearningProgrammingLanguagesToMembers < ActiveRecord::Migration[7.1]
+  def change
+    change_column :members, :learning_programming_languages, :integer
+  end
+end

--- a/n_app/db/schema.rb
+++ b/n_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_09_032718) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_06_062750) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_09_032718) do
     t.string "name"
     t.string "student_id"
     t.string "grade"
-    t.bigint "learning_programming_languages", default: 0
+    t.integer "learning_programming_languages", default: 0
     t.text "intro"
     t.integer "department"
     t.boolean "admin", default: false


### PR DESCRIPTION
プログラミング言語を選択するチェックボックスの機能を修正して、一度選択した言語を保持できるようになった。
また、データ型をintegerに変更した。