### PR TITLE
Feature change destroy to destroy member in site admins controller ankhbold

### DIFF
--- a/n_app/app/controllers/members_controller.rb
+++ b/n_app/app/controllers/members_controller.rb
@@ -1,6 +1,6 @@
 class MembersController < ApplicationController
   def index
-    @members = Member.where.not(member_role: 2)
+    @members = Member.all
   end
 
   def show

--- a/n_app/app/controllers/site_admins_controller.rb
+++ b/n_app/app/controllers/site_admins_controller.rb
@@ -65,7 +65,7 @@ class SiteAdminsController < ApplicationController
     redirect_to member_editor_path, notice: "Grades decremented successfully!"
   end
 
-  def destroy
+  def destroy_member
     @member = Member.find(params[:id])
     @member.destroy
 

--- a/n_app/app/controllers/site_admins_controller.rb
+++ b/n_app/app/controllers/site_admins_controller.rb
@@ -1,6 +1,6 @@
 class SiteAdminsController < ApplicationController
   before_action :validate_access_permission
-  before_action :check_for_admin, only: [:destroy, :grant_mod_status, :revoke_mod_status]
+  before_action :check_for_admin, only: [:destroy_member, :grant_mod_status, :revoke_mod_status]
 
   def validate_access_permission
     unless current_member.member_role == "admin" || current_member.member_role == "mod"

--- a/n_app/app/views/site_admins/member_editor.html.erb
+++ b/n_app/app/views/site_admins/member_editor.html.erb
@@ -44,7 +44,7 @@
           <td>
             <% if member.member_role == "user" %>
               <div class="full-width-container">
-                <%= link_to destroy_path(member.id), data: { turbo_method: :delete, turbo_confirm: "<<<REMOVE MEMBERSHIP>>>\nPROCEED?" }, class:"btn btn-danger btn-sm full-width-button" do %>
+                <%= link_to destroy_member_path(member.id), data: { turbo_method: :delete, turbo_confirm: "<<<REMOVE MEMBERSHIP>>>\nPROCEED?" }, class:"btn btn-danger btn-sm full-width-button" do %>
                   <i class="bi bi-person-x"></i> Remove Membership
                 <% end %>
               </div>

--- a/n_app/config/routes.rb
+++ b/n_app/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   patch 'revoke_mod_status/:id', to: 'site_admins#revoke_mod_status', as: 'revoke_mod_status'
   patch 'grant_admin_status/:id', to: 'site_admins#grant_admin_status', as: 'grant_admin_status'
   patch 'revoke_admin_status/:id', to: 'site_admins#revoke_admin_status', as: 'revoke_admin_status'
-  delete 'site_admins/:id', to: "site_admins#destroy", as: "destroy"
+  delete 'site_admins/:id', to: "site_admins#destroy_member", as: "destroy_member"
 
   get 'site_admins/carousel_editor', to: "site_admins#carousel_editor", as: "carousel_editor"
   post 'site_admins/create_image', to: 'site_admins#create_image', as: "create_image"


### PR DESCRIPTION
Changed the function to delete members from "destroy" to "destroy_member" in all relevant codebase sections for better readibility.