### PR TITLE
Feature 11 a

### DIFF
--- a/n_app/app/controllers/activities_controller.rb
+++ b/n_app/app/controllers/activities_controller.rb
@@ -1,4 +1,6 @@
 class ActivitiesController < ApplicationController
+  require "mini_magick"
+
   def index
     if params[:search].present?
       search_term = "%#{params[:search]}%"
@@ -22,8 +24,19 @@ class ActivitiesController < ApplicationController
   end
 
   def create
-    @activity = Activity.new(activity_params)
+    @activity = Activity.new(activity_params.except(:activity_image))
+    # puts "DEBUG: params[:activity][:activity_image] = #{params[:activity][:activity_image].inspect}"
+    # 画像がアップロードされている場合のみ処理
+    if params[:activity][:activity_image].present?
+      compressed_image = compress_image(params[:activity][:activity_image], "new")
+      @activity.activity_image.attach(
+        io: compressed_image,
+        filename: "#{File.basename(params[:activity][:activity_image].original_filename, '.*')}.jpg",
+        content_type: "image/jpeg"
+      )
+    end
     @activity.member_id = current_member.id
+
     if @activity.save
       redirect_to activities_path
     else
@@ -42,8 +55,20 @@ class ActivitiesController < ApplicationController
 
   def update
     @activity = Activity.find(params[:id])
+    # puts "DEBUG: params[:activity][:activity_image] = #{params[:activity][:activity_image].inspect}"
+    if params[:activity][:activity_image].present?
+      compressed_image = compress_image(params[:activity][:activity_image], "edit")
+      # 既存の画像を削除
+      @activity.activity_image.purge if @activity.activity_image.attached?
+      # 圧縮後の画像をアップロード
+      @activity.activity_image.attach(
+        io: compressed_image,
+        filename: "#{File.basename(params[:activity][:activity_image].original_filename, '.*')}.jpg",
+        content_type: "image/jpeg"
+      )
+    end
 
-    if @activity.update(activity_params)
+    if @activity.update(activity_params.except(:activity_image))
       redirect_to activity_path
     else
       render :edit, status: :unprocessable_entity
@@ -58,6 +83,15 @@ class ActivitiesController < ApplicationController
 
   def save_draft
     @activity = Activity.new(activity_params)
+    # 画像がアップロードされている場合のみ処理
+    if params[:activity][:activity_image].present?
+      compressed_image = compress_image(params[:activity][:activity_image], "new")
+      @activity.activity_image.attach(
+        io: compressed_image,
+        filename: "#{File.basename(params[:activity][:activity_image].original_filename, '.*')}.jpg",
+        content_type: "image/jpeg"
+      )
+    end
     @activity.member_id = current_member.id
     @activity.published = false
 
@@ -70,16 +104,28 @@ class ActivitiesController < ApplicationController
 
   def change_publish
     @activity = Activity.find(params[:id])
-    @activity.assign_attributes(activity_params)
+
+    if params[:activity][:activity_image].present?
+      compressed_image = compress_image(params[:activity][:activity_image], "edit")
+      # 既存の画像を削除
+      @activity.activity_image.purge if @activity.activity_image.attached?
+      # 圧縮後の画像をアップロード
+      @activity.activity_image.attach(
+        io: compressed_image,
+        filename: "#{File.basename(params[:activity][:activity_image].original_filename, '.*')}.jpg",
+        content_type: "image/jpeg"
+      )
+    end
+
     if @activity.published
-      @activity.update(published: false)
+      @activity.published = false
       notice_message = '記事が非公開になりました。'
     else
-      @activity.update(published: true)
+      @activity.published = true
       notice_message = '記事が公開されました。'
     end
 
-    if @activity.save
+    if @activity.update(activity_params.except(:activity_image))
       redirect_to activity_path(@activity), notice: notice_message
     else
       render :edit, status: :unprocessable_entity
@@ -90,5 +136,29 @@ class ActivitiesController < ApplicationController
 
   def activity_params
     params.require(:activity).permit(:title, :body, :activity_image, :published)
+  end
+
+  def compress_image(uploaded_file, action)
+    image = MiniMagick::Image.open(uploaded_file.tempfile.path)
+    # # 画像を圧縮・リサイズ
+    if image.width > 840
+      image.resize "840x"
+    else
+      image.quality "50"
+    end
+    image.format "jpeg"
+
+    tempfile = Tempfile.new(["compressed", ".jpg"])
+    image.write(tempfile.path)
+    tempfile.rewind
+
+    # アクション別に扱うデータを分ける
+    if action == "new"
+      io = StringIO.new(tempfile.read)
+      io.rewind
+      io
+    else
+      tempfile
+    end
   end
 end

--- a/n_app/app/controllers/api/v1/activities_controller.rb
+++ b/n_app/app/controllers/api/v1/activities_controller.rb
@@ -1,7 +1,6 @@
 module Api
   module V1
     class ActivitiesController < ApplicationController
-      require "mini_magick"
       include MarkdownHelper
 
       def preview
@@ -14,7 +13,6 @@ module Api
 
         # 挿入された画像を取得
         dragged_image = params[:image]
-        file_size = dragged_image.tempfile.size
 
         # 画像を圧縮
         compressed_image = MiniMagick::Image.open(dragged_image.tempfile.path)


### PR DESCRIPTION
- top画像に添付する画像サイズは、5MB未満。5MB以上では保存できない。
- 画像を保存する際は、画像サイズを削減。幅が840以上の場合、縦横幅の大きい方を840にリサイズ。以下の場合は、50%に圧縮。